### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ iparq inspect important.parquet temp_*.parquet
 
 When inspecting multiple files, each file's results are displayed with a header showing the filename. The utility will read the metadata of each file and print the compression codecs used in the parquet files.
 
-## Example ouput - Bloom Filters
+## Example output - Bloom Filters
 
 ```log
 ParquetMetaModel(


### PR DESCRIPTION
## Summary
- correct typo in example header

## Testing
- `uv pip install --system -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857e672a2e8832fb7aa9bf5bdc52140