### PR TITLE
Fix iParq 0.6.0 publisher action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -47,8 +47,7 @@ jobs:
         run: uv run ty check
 
       - name: Run tests
-        run: |
-          uv run pytest -v
+        run: uv run pytest -v --cov=src/iparq --cov-report=html
 
       - name: Test package build
         run: |
@@ -131,6 +130,8 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@2834a314042ef964da07689278dd1e9d773e8afd # v1.14.1
+        # This container action maps its ref to a GHCR image tag, so a commit SHA
+        # cannot resolve. Use the exact release tag recommended by the publisher.
+        uses: pypa/gh-action-pypi-publish@v1.14.1
         with:
           packages-dir: dist/


### PR DESCRIPTION
## Summary

- use the publisher exact release tag because its container trampoline maps the action ref to a GHCR image tag (the previous full SHA image does not exist)
- generate the coverage artifacts already configured for upload

## Evidence

- `v1.14.1` GHCR manifest resolves; the former SHA manifest returns 404
- actionlint and diff checks pass
- 29 tests pass and produce `.coverage` plus `htmlcov/index.html`
- independent peer review found no blocker

This fixes the infrastructure-only failure in release run 29770206348; its test/validation and build jobs both passed.