### PR TITLE
Publish iParq ARD catalog

### DIFF
--- a/.agents/skills/iparq-parquet-inspector/SKILL.md
+++ b/.agents/skills/iparq-parquet-inspector/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: iparq-parquet-inspector
+description: Inspect Parquet file metadata with the iParq CLI, including compression, encodings, physical and logical types, row groups, statistics, dictionary pages, page indexes, Bloom filters, and storage sizes. Use when an agent needs to explain how one or more .parquet files were written, compare their storage-level features, diagnose missing Parquet optimizations, or obtain machine-readable Parquet metadata without reading the row data.
+---
+
+# iParq Parquet Inspector
+
+Inspect Parquet storage metadata without querying the file's row data. Prefer JSON output so results remain machine-readable and diagnostics stay separate on stderr.
+
+## Run an inspection
+
+Use the published package without installing it permanently:
+
+```sh
+uvx --refresh iparq inspect FILE.parquet --format json --details --sizes
+```
+
+If `iparq` is already installed, run it directly:
+
+```sh
+iparq inspect FILE.parquet --format json --details --sizes
+```
+
+Pass multiple paths or shell-expanded glob patterns to compare files. iParq emits one JSON object for a single file and an array with a `file` field for multiple files.
+
+## Select the minimum useful detail
+
+- Use `--metadata-only` for creator, row count, row groups, Parquet version, and serialized metadata size.
+- Use `--column NAME` to restrict column-level output.
+- Use `--details` for encodings, physical and logical types, dictionary pages, page indexes, Bloom-filter metadata, and detailed statistics.
+- Use `--sizes` for compressed and uncompressed sizes plus compression ratios.
+- Keep `--format json` for agent workflows. Use the default Rich output only when a human explicitly wants a table.
+
+## Interpret results
+
+Report observed facts separately from recommendations. In particular:
+
+- Treat `has_bloom_filter`, `has_column_index`, and `has_offset_index` as metadata evidence, not proof that a query engine will use those structures.
+- Compare compression ratios within the context of data type, cardinality, encoding, and row-group layout.
+- Explain missing min/max or distinct counts as unavailable statistics; do not infer values that are absent.
+- Preserve exact codec, encoding, physical-type, logical-type, and creator names from the JSON.
+- Mention the affected file and column when comparing multiple inputs.
+
+## Handle failures
+
+Do not modify the inspected files. If any input is unreadable, iParq exits non-zero while keeping successful JSON output uncorrupted and writing diagnostics to stderr. Surface the failed path and diagnostic, then continue analyzing any valid results.

--- a/.agents/skills/iparq-parquet-inspector/agents/openai.yaml
+++ b/.agents/skills/iparq-parquet-inspector/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "iParq Parquet Inspector"
+  short_description: "Inspect Parquet internals with structured output"
+  default_prompt: "Use $iparq-parquet-inspector to inspect these Parquet files and explain their storage-level metadata."

--- a/.github/workflows/ai-catalog.yml
+++ b/.github/workflows/ai-catalog.yml
@@ -1,0 +1,65 @@
+name: Publish AI catalog
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".agents/skills/**"
+      - ".well-known/**"
+      - "catalog-site/**"
+      - ".github/workflows/ai-catalog.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout iParq
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Checkout ARD conformance tool
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ards-project/ard-spec
+          ref: 5fa2f5aef790b478319f6a3b43adf4661b0ed0e0
+          path: .ard-spec
+
+      - name: Install strict schema validator
+        run: python -m pip install --disable-pip-version-check jsonschema==4.25.1
+
+      - name: Validate ARD manifest
+        run: python .ard-spec/conformance/bin/conformance-test manifest .well-known/ai-catalog.json
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Assemble catalog site
+        run: |
+          mkdir -p _site/.well-known
+          cp -R catalog-site/. _site/
+          cp .well-known/ai-catalog.json _site/.well-known/ai-catalog.json
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy catalog to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.well-known/ai-catalog.json
+++ b/.well-known/ai-catalog.json
@@ -1,0 +1,58 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "iParq",
+    "identifier": "github.com",
+    "documentationUrl": "https://github.com/MiguelElGallo/iparq"
+  },
+  "entries": [
+    {
+      "identifier": "urn:air:github.com:MiguelElGallo:iparq:parquet-inspector",
+      "displayName": "iParq Parquet Inspector",
+      "type": "text/markdown; profile=\"urn:air:agent-skills\"",
+      "url": "https://raw.githubusercontent.com/MiguelElGallo/iparq/main/.agents/skills/iparq-parquet-inspector/SKILL.md",
+      "description": "Inspect Parquet metadata, compression, encodings, physical and logical types, row groups, statistics, indexes, dictionary pages, Bloom filters, and storage sizes through a read-only CLI with machine-readable JSON output.",
+      "tags": [
+        "parquet",
+        "metadata",
+        "compression",
+        "encoding",
+        "bloom-filter",
+        "data-engineering",
+        "cli"
+      ],
+      "capabilities": [
+        "InspectParquetMetadata",
+        "CompareParquetFiles",
+        "DetectParquetBloomFilters",
+        "AnalyzeParquetCompression",
+        "EmitParquetMetadataJson"
+      ],
+      "representativeQueries": [
+        "inspect the compression and encodings used in this Parquet file",
+        "does this Parquet file contain Bloom filters or page indexes",
+        "show the row groups statistics and physical and logical types in this Parquet file",
+        "compare storage metadata across these Parquet files",
+        "produce machine-readable metadata for this Parquet file"
+      ],
+      "version": "0.6.0",
+      "updatedAt": "2026-07-20T00:00:00Z",
+      "metadata": {
+        "package": "https://pypi.org/project/iparq/",
+        "sourceRepository": "https://github.com/MiguelElGallo/iparq",
+        "sourcePath": ".agents/skills/iparq-parquet-inspector",
+        "invocation": "uvx --refresh iparq inspect FILE.parquet --format json --details --sizes"
+      },
+      "trustManifest": {
+        "identity": "https://github.com/MiguelElGallo/iparq",
+        "identityType": "https",
+        "provenance": [
+          {
+            "relation": "publishedFrom",
+            "sourceId": "https://github.com/MiguelElGallo/iparq"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ object; multiple files produce one JSON array whose entries include `file`.
 Diagnostics are written to stderr, and any unreadable input makes the command
 exit non-zero without corrupting successful JSON output.
 
+## Agent discovery
+
+iParq publishes an [Agentic Resource Discovery (ARD) catalog](https://miguelelgallo.github.io/iparq/.well-known/ai-catalog.json)
+and a portable [Parquet inspection skill](.agents/skills/iparq-parquet-inspector/SKILL.md)
+for AI clients. The catalog advertises the existing read-only CLI and its JSON
+output; it does not add a network service or change how iParq accesses files.
+
 ## Example output
 
 ```log

--- a/catalog-site/index.html
+++ b/catalog-site/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="ai-catalog" href="./.well-known/ai-catalog.json">
+    <title>iParq AI Catalog</title>
+  </head>
+  <body>
+    <main>
+      <h1>iParq AI Catalog</h1>
+      <p>Discover the iParq Parquet inspection skill through its <a href="./.well-known/ai-catalog.json">ARD catalog manifest</a>.</p>
+      <p><a href="https://github.com/MiguelElGallo/iparq">Source and documentation</a></p>
+    </main>
+  </body>
+</html>

--- a/catalog-site/robots.txt
+++ b/catalog-site/robots.txt
@@ -1,0 +1,4 @@
+Agentmap: https://miguelelgallo.github.io/iparq/.well-known/ai-catalog.json
+
+User-agent: *
+Allow: /

--- a/tests/test_ai_catalog.py
+++ b/tests/test_ai_catalog.py
@@ -1,0 +1,36 @@
+import json
+import re
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+CATALOG_PATH = REPOSITORY_ROOT / ".well-known" / "ai-catalog.json"
+URN_PATTERN = re.compile(r"^urn:air:[a-zA-Z0-9.-]+(:[a-zA-Z0-9._-]+)+$")
+
+
+def test_ai_catalog_entries_are_discoverable() -> None:
+    catalog = json.loads(CATALOG_PATH.read_text())
+
+    assert catalog["specVersion"] == "1.0"
+    assert catalog["host"]["displayName"]
+    assert catalog["entries"]
+
+    for entry in catalog["entries"]:
+        assert URN_PATTERN.fullmatch(entry["identifier"])
+        assert entry["displayName"]
+        assert entry["type"]
+        assert ("url" in entry) != ("data" in entry)
+        assert 2 <= len(entry["representativeQueries"]) <= 5
+
+
+def test_cataloged_skill_exists_and_has_matching_identity() -> None:
+    catalog = json.loads(CATALOG_PATH.read_text())
+    entry = catalog["entries"][0]
+    skill_path = REPOSITORY_ROOT / entry["metadata"]["sourcePath"] / "SKILL.md"
+    skill = skill_path.read_text()
+
+    assert skill_path.is_file()
+    assert entry["type"] == 'text/markdown; profile="urn:air:agent-skills"'
+    assert skill.startswith("---\nname: iparq-parquet-inspector\n")
+    assert "Use when" in skill.split("---", 2)[1]
+    assert entry["version"] == "0.6.0"


### PR DESCRIPTION
## What changed

- add a portable iParq Parquet inspection Agent Skill
- publish a conformant `.well-known/ai-catalog.json` manifest
- add HTML and `Agentmap` discovery hints
- deploy the catalog through GitHub Pages
- test catalog-to-skill integrity

## Why

Agentic Resource Discovery clients need structured metadata, representative queries, a stable resource identity, and a retrievable artifact before they can discover iParq for Parquet inspection tasks.

## Impact

The existing read-only CLI and its JSON contract remain unchanged. GitHub Pages publishes only the static ARD catalog surface.

## Validation

- official ARD conformance tool with strict JSON Schema: 0 errors, 0 warnings
- skill creator validator: pass
- `uv run pytest -vv`: 31 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run mypy src/iparq --config-file=pyproject.toml`
- `actionlint .github/workflows/ai-catalog.yml`
- fresh-context skill execution against `tests/dummy.parquet`: pass