### PR TITLE
Include ARD manifest in Pages artifact

### DIFF
--- a/.github/workflows/ai-catalog.yml
+++ b/.github/workflows/ai-catalog.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: _site
+          include-hidden-files: true
 
   deploy:
     environment:


### PR DESCRIPTION
## What changed

Enable hidden-file inclusion for the tightly scoped `_site` GitHub Pages artifact.

## Why

`actions/upload-pages-artifact@v5` excludes dot-prefixed files and directories by default. The first successful deployment therefore omitted `_site/.well-known/ai-catalog.json`, while the non-hidden landing page and `robots.txt` were published.

## Impact

The controlled `_site` artifact now includes the required ARD `/.well-known/` manifest. No repository secrets or checkout-wide hidden files are uploaded.

## Validation

- `actionlint .github/workflows/ai-catalog.yml`
- first deployment diagnosis: landing page and `robots.txt` live; manifest returned 404
- action documentation confirms `include-hidden-files` defaults to `false`