### PR TITLE
Improve agent discovery for iparq.dev

### DIFF
--- a/.well-known/ai-catalog.json
+++ b/.well-known/ai-catalog.json
@@ -3,11 +3,11 @@
   "host": {
     "displayName": "iParq",
     "identifier": "iparq.dev",
-    "documentationUrl": "https://github.com/MiguelElGallo/iparq"
+    "documentationUrl": "https://iparq.dev/docs/"
   },
   "entries": [
     {
-      "identifier": "urn:air:github.com:MiguelElGallo:iparq:parquet-inspector",
+      "identifier": "urn:air:iparq.dev:skill:parquet-inspector",
       "displayName": "iParq Parquet Inspector",
       "type": "text/markdown; profile=\"urn:air:agent-skills\"",
       "url": "https://raw.githubusercontent.com/MiguelElGallo/iparq/main/.agents/skills/iparq-parquet-inspector/SKILL.md",
@@ -36,15 +36,17 @@
         "produce machine-readable metadata for this Parquet file"
       ],
       "version": "0.6.0",
-      "updatedAt": "2026-07-20T00:00:00Z",
+      "updatedAt": "2026-07-22T00:00:00Z",
       "metadata": {
         "package": "https://pypi.org/project/iparq/",
+        "homepage": "https://iparq.dev/",
+        "documentation": "https://iparq.dev/docs/",
         "sourceRepository": "https://github.com/MiguelElGallo/iparq",
         "sourcePath": ".agents/skills/iparq-parquet-inspector",
         "invocation": "uvx --refresh iparq inspect FILE.parquet --format json --details --sizes"
       },
       "trustManifest": {
-        "identity": "https://github.com/MiguelElGallo/iparq",
+        "identity": "https://iparq.dev/",
         "identityType": "https",
         "provenance": [
           {

--- a/README.md
+++ b/README.md
@@ -141,10 +141,12 @@ exit non-zero without corrupting successful JSON output.
 
 ## Agent discovery
 
-iParq publishes an [Agentic Resource Discovery (ARD) catalog](https://iparq.dev/.well-known/ai-catalog.json)
-and a portable [Parquet inspection skill](.agents/skills/iparq-parquet-inspector/SKILL.md)
-for AI clients. The catalog advertises the existing read-only CLI and its JSON
-output; it does not add a network service or change how iParq accesses files.
+iParq publishes [CLI and Agent Skill documentation](https://iparq.dev/docs/), an
+[Agentic Resource Discovery (ARD) catalog](https://iparq.dev/.well-known/ai-catalog.json),
+an [agent-readable documentation index](https://iparq.dev/llms.txt), and a
+portable [Parquet inspection skill](.agents/skills/iparq-parquet-inspector/SKILL.md).
+The catalog advertises the existing read-only CLI and its JSON output; it does
+not add a network service or change how iParq accesses files.
 
 ## Example output
 

--- a/catalog-site/docs/index.html
+++ b/catalog-site/docs/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Install and use the iParq CLI and Agent Skill to inspect local Parquet metadata safely with human-readable tables or JSON output.">
+    <link rel="canonical" href="https://iparq.dev/docs/">
+    <link rel="ai-catalog" href="https://iparq.dev/.well-known/ai-catalog.json">
+    <title>iParq documentation — CLI and Agent Skill</title>
+  </head>
+  <body>
+    <header>
+      <nav aria-label="Primary navigation"><a href="/">iParq home</a> · <a href="https://github.com/MiguelElGallo/iparq">Source</a></nav>
+    </header>
+    <main>
+      <h1>iParq CLI and Agent Skill documentation</h1>
+      <p>iParq inspects Parquet storage metadata locally. It does not upload inspected files, expose a hosted API, or modify input data. Python 3.10 or later is required.</p>
+
+      <h2>Quick start</h2>
+      <pre><code>uvx --refresh iparq inspect FILE.parquet --format json --details --sizes</code></pre>
+      <p>Use <code>pip install iparq</code> for a persistent installation. The default output is a Rich table for people; <code>--format json</code> is the stable choice for scripts and agents.</p>
+
+      <h2>Inspection options</h2>
+      <ul>
+        <li><code>--metadata-only</code> reports creator, row count, row groups, Parquet version, and serialized metadata size.</li>
+        <li><code>--column NAME</code> restricts column-level output.</li>
+        <li><code>--details</code> adds encodings, physical and logical types, dictionary pages, page indexes, Bloom-filter metadata, and detailed statistics.</li>
+        <li><code>--sizes</code> adds compressed and uncompressed sizes plus compression ratios.</li>
+      </ul>
+
+      <h2>Machine-readable contract</h2>
+      <p>A single input emits one JSON object. Multiple inputs emit one JSON array whose entries include the file path. Diagnostics are written to stderr. If any input is unreadable, the process exits non-zero while keeping successful JSON output valid.</p>
+
+      <h2>Agent use</h2>
+      <p>The <a href="https://raw.githubusercontent.com/MiguelElGallo/iparq/main/.agents/skills/iparq-parquet-inspector/SKILL.md">iParq Parquet Inspector Skill</a> explains when to invoke the CLI, how to select the minimum useful detail, and how to distinguish observed metadata from recommendations. The <a href="/.well-known/ai-catalog.json">ARD catalog</a> publishes representative queries and the canonical Skill URL.</p>
+
+      <h2>Safety boundary</h2>
+      <p>iParq is read-only and local. It inspects file metadata without querying row data. Treat index and Bloom-filter fields as evidence that structures exist, not as proof that a downstream engine will use them. Preserve exact codec, encoding, physical-type, logical-type, and creator names when reporting results.</p>
+    </main>
+    <footer><p><a href="https://pypi.org/project/iparq/">PyPI package</a> · <a href="https://github.com/MiguelElGallo/iparq/issues">Issues</a> · <a href="/pricing.md">Pricing and license</a></p></footer>
+  </body>
+</html>

--- a/catalog-site/index.html
+++ b/catalog-site/index.html
@@ -3,15 +3,108 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="iParq is a free, local, read-only CLI and Agent Skill for inspecting Parquet metadata, compression, encodings, indexes, statistics, and Bloom filters.">
     <link rel="canonical" href="https://iparq.dev/">
     <link rel="ai-catalog" href="https://iparq.dev/.well-known/ai-catalog.json">
-    <title>iParq AI Catalog</title>
+    <link rel="alternate" type="text/markdown" href="https://iparq.dev/index.md" title="iParq for agents">
+    <meta property="og:title" content="iParq — inspect Parquet storage metadata locally">
+    <meta property="og:description" content="A free, read-only CLI and Agent Skill for inspecting Parquet metadata without uploading file contents.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://iparq.dev/">
+    <meta property="og:image" content="https://raw.githubusercontent.com/MiguelElGallo/iparq/main/media/iparq.png">
+    <title>iParq — local Parquet metadata inspector</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "iParq",
+        "url": "https://iparq.dev/",
+        "description": "A local, read-only command-line tool and Agent Skill for inspecting Parquet metadata, compression, encodings, physical and logical types, row groups, statistics, indexes, dictionary pages, Bloom filters, and storage sizes.",
+        "applicationCategory": "DeveloperApplication",
+        "applicationSubCategory": "Data engineering tool",
+        "operatingSystem": "Linux, macOS, Windows",
+        "softwareVersion": "0.6.0",
+        "programmingLanguage": "Python",
+        "license": "https://opensource.org/license/mit",
+        "downloadUrl": "https://pypi.org/project/iparq/",
+        "codeRepository": "https://github.com/MiguelElGallo/iparq",
+        "sameAs": [
+          "https://github.com/MiguelElGallo/iparq",
+          "https://pypi.org/project/iparq/"
+        ],
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD",
+          "description": "Free and open-source under the MIT License"
+        }
+      }
+    </script>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.6;
+      }
+      body {
+        margin: 0;
+      }
+      header,
+      main,
+      footer {
+        margin: 0 auto;
+        max-width: 54rem;
+        padding: 1rem 1.5rem;
+      }
+      nav a {
+        margin-right: 1rem;
+      }
+      code,
+      pre {
+        font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+      }
+      pre {
+        border: 1px solid currentColor;
+        border-radius: 0.5rem;
+        overflow-x: auto;
+        padding: 1rem;
+      }
+      .lede {
+        font-size: 1.2rem;
+      }
+    </style>
   </head>
   <body>
+    <header>
+      <nav aria-label="Primary navigation">
+        <a href="/">Home</a>
+        <a href="/docs/">Documentation</a>
+        <a href="https://pypi.org/project/iparq/">PyPI</a>
+        <a href="https://github.com/MiguelElGallo/iparq">GitHub</a>
+      </nav>
+    </header>
     <main>
-      <h1>iParq AI Catalog</h1>
-      <p>Discover the iParq Parquet inspection skill through its <a href="https://iparq.dev/.well-known/ai-catalog.json">ARD catalog manifest</a>.</p>
-      <p><a href="https://github.com/MiguelElGallo/iparq">Source and documentation</a></p>
+      <h1>Inspect Parquet storage metadata locally</h1>
+      <p class="lede">iParq is a free, open-source command-line tool and Agent Skill for understanding how Parquet files were written. It reports metadata without querying row data and without uploading files to a remote service.</p>
+
+      <h2>What iParq reveals</h2>
+      <p>Inspect compression codecs, encodings, physical and logical types, row groups, min/max and null statistics, dictionary pages, column and offset indexes, Bloom-filter metadata, compressed sizes, and compression ratios. Compare several files or restrict an inspection to one column when diagnosing storage layout and missing optimizations.</p>
+
+      <h2>Run it without installing</h2>
+      <pre><code>uvx --refresh iparq inspect FILE.parquet --format json --details --sizes</code></pre>
+      <p>The JSON output is designed for scripts and agent workflows. A single file produces one object; multiple files produce an array with a <code>file</code> field. Diagnostics go to stderr, and unreadable inputs return a non-zero exit status without corrupting successful JSON output.</p>
+
+      <h2>When agents should use it</h2>
+      <p>Use iParq when a task asks how a local Parquet file is encoded or compressed, whether it contains page indexes or Bloom filters, how row groups and statistics are arranged, or how storage metadata differs across files. Observed metadata is evidence about the file structure; it is not proof that a particular query engine will use an optimization.</p>
+
+      <h2>Agent discovery</h2>
+      <p>Agents can discover iParq through the <a href="/.well-known/ai-catalog.json">ARD catalog</a>, read the portable <a href="https://raw.githubusercontent.com/MiguelElGallo/iparq/main/.agents/skills/iparq-parquet-inspector/SKILL.md">Parquet inspection Skill</a>, or start with the <a href="/llms.txt">machine-readable documentation index</a>. Discovery does not create a network service: inspections still run locally through the published Python package.</p>
+
+      <h2>Documentation and source</h2>
+      <p>Read the <a href="/docs/">CLI and agent documentation</a>, install the package from <a href="https://pypi.org/project/iparq/">PyPI</a>, or review the implementation, tests, and MIT license in the <a href="https://github.com/MiguelElGallo/iparq">GitHub repository</a>. iParq is free to use; see the concise <a href="/pricing.md">pricing and license summary</a>.</p>
     </main>
+    <footer>
+      <p>iParq is maintained as an open-source project. Parquet files remain on the machine where the CLI runs.</p>
+    </footer>
   </body>
 </html>

--- a/catalog-site/index.md
+++ b/catalog-site/index.md
@@ -1,0 +1,33 @@
+# iParq — local Parquet metadata inspector
+
+iParq is a free, MIT-licensed command-line tool and Agent Skill for inspecting how local Parquet files were written. It reports metadata without querying row data, uploading files, or modifying inputs.
+
+## When to use iParq
+
+Use iParq to inspect or compare:
+
+- compression codecs and ratios;
+- encodings plus physical and logical types;
+- row groups and available min/max, null, and distinct statistics;
+- dictionary pages, column indexes, and offset indexes;
+- Bloom-filter offsets and sizes;
+- creator, format version, row count, and serialized metadata size.
+
+## Agent-safe invocation
+
+```sh
+uvx --refresh iparq inspect FILE.parquet --format json --details --sizes
+```
+
+A single file produces one JSON object. Multiple files produce an array whose entries include `file`. Diagnostics are written to stderr. Any unreadable input makes the command exit non-zero while leaving successful JSON output valid.
+
+Treat observed metadata separately from recommendations. The presence of a Bloom filter or page index does not prove that a query engine will use it.
+
+## Resources
+
+- [CLI and Agent Skill documentation](https://iparq.dev/docs/)
+- [ARD catalog](https://iparq.dev/.well-known/ai-catalog.json)
+- [Parquet Inspector Skill](https://raw.githubusercontent.com/MiguelElGallo/iparq/main/.agents/skills/iparq-parquet-inspector/SKILL.md)
+- [PyPI](https://pypi.org/project/iparq/)
+- [GitHub](https://github.com/MiguelElGallo/iparq)
+- [Pricing and license](https://iparq.dev/pricing.md)

--- a/catalog-site/llms.txt
+++ b/catalog-site/llms.txt
@@ -1,0 +1,26 @@
+# iParq
+
+> iParq is a free, open-source, local and read-only CLI plus Agent Skill for inspecting Parquet storage metadata without uploading files.
+
+## Use iParq when
+
+- You need to inspect Parquet compression, encodings, physical or logical types.
+- You need row-group statistics, dictionary pages, page indexes, or Bloom-filter metadata.
+- You need to compare storage metadata across local Parquet files.
+- You need machine-readable JSON for an agent or script.
+
+## Run
+
+`uvx --refresh iparq inspect FILE.parquet --format json --details --sizes`
+
+## Canonical resources
+
+- [Documentation](https://iparq.dev/docs/)
+- [Agent-readable overview](https://iparq.dev/index.md)
+- [ARD catalog](https://iparq.dev/.well-known/ai-catalog.json)
+- [Parquet Inspector Skill](https://raw.githubusercontent.com/MiguelElGallo/iparq/main/.agents/skills/iparq-parquet-inspector/SKILL.md)
+- [PyPI package](https://pypi.org/project/iparq/)
+- [Source repository](https://github.com/MiguelElGallo/iparq)
+- [Pricing and license](https://iparq.dev/pricing.md)
+
+Inspections run on the user's machine. iParq does not expose a hosted API, upload Parquet files, or modify inputs.

--- a/catalog-site/pricing.md
+++ b/catalog-site/pricing.md
@@ -1,0 +1,7 @@
+# iParq pricing and license
+
+iParq is free to install and use. There are no paid tiers, API charges, subscriptions, usage limits, or remote-service fees.
+
+The source code is available under the [MIT License](https://github.com/MiguelElGallo/iparq/blob/main/LICENSE), and the Python package is published on [PyPI](https://pypi.org/project/iparq/).
+
+iParq runs locally. Users provide their own computer and storage, and inspected Parquet files are not uploaded to an iParq service.

--- a/catalog-site/robots.txt
+++ b/catalog-site/robots.txt
@@ -1,4 +1,5 @@
 Agentmap: https://iparq.dev/.well-known/ai-catalog.json
+Sitemap: https://iparq.dev/sitemap.xml
 
 User-agent: *
 Allow: /

--- a/catalog-site/sitemap.xml
+++ b/catalog-site/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://iparq.dev/</loc>
+  </url>
+  <url>
+    <loc>https://iparq.dev/docs/</loc>
+  </url>
+  <url>
+    <loc>https://iparq.dev/index.md</loc>
+  </url>
+  <url>
+    <loc>https://iparq.dev/llms.txt</loc>
+  </url>
+  <url>
+    <loc>https://iparq.dev/pricing.md</loc>
+  </url>
+  <url>
+    <loc>https://iparq.dev/.well-known/ai-catalog.json</loc>
+  </url>
+</urlset>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ checks = [
 iparq = "iparq.source:app"
 
 [project.urls]
-Homepage = "https://github.com/MiguelElGallo/iparq"
+Homepage = "https://iparq.dev/"
+Documentation = "https://iparq.dev/docs/"
 Repository = "https://github.com/MiguelElGallo/iparq"
 Issues = "https://github.com/MiguelElGallo/iparq/issues"
 

--- a/tests/test_ai_catalog.py
+++ b/tests/test_ai_catalog.py
@@ -67,9 +67,10 @@ def test_sitemap_uses_canonical_https_urls() -> None:
         for element in sitemap.findall("sitemap:url/sitemap:loc", namespace)
     ]
 
-    assert "https://iparq.dev/" in locations
-    assert "https://iparq.dev/.well-known/ai-catalog.json" in locations
     parsed_locations = [urlsplit(location) for location in locations if location]
     assert len(parsed_locations) == len(locations)
     assert all(location.scheme == "https" for location in parsed_locations)
     assert all(location.hostname == "iparq.dev" for location in parsed_locations)
+    paths = {location.path for location in parsed_locations}
+    assert "/" in paths
+    assert "/.well-known/ai-catalog.json" in paths

--- a/tests/test_ai_catalog.py
+++ b/tests/test_ai_catalog.py
@@ -1,10 +1,12 @@
 import json
 import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 
 REPOSITORY_ROOT = Path(__file__).parents[1]
 CATALOG_PATH = REPOSITORY_ROOT / ".well-known" / "ai-catalog.json"
+SITE_PATH = REPOSITORY_ROOT / "catalog-site"
 URN_PATTERN = re.compile(r"^urn:air:[a-zA-Z0-9.-]+(:[a-zA-Z0-9._-]+)+$")
 
 
@@ -13,10 +15,13 @@ def test_ai_catalog_entries_are_discoverable() -> None:
 
     assert catalog["specVersion"] == "1.0"
     assert catalog["host"]["displayName"]
+    assert catalog["host"]["identifier"] == "iparq.dev"
+    assert catalog["host"]["documentationUrl"] == "https://iparq.dev/docs/"
     assert catalog["entries"]
 
     for entry in catalog["entries"]:
         assert URN_PATTERN.fullmatch(entry["identifier"])
+        assert entry["identifier"].startswith("urn:air:iparq.dev:")
         assert entry["displayName"]
         assert entry["type"]
         assert ("url" in entry) != ("data" in entry)
@@ -34,3 +39,35 @@ def test_cataloged_skill_exists_and_has_matching_identity() -> None:
     assert skill.startswith("---\nname: iparq-parquet-inspector\n")
     assert "Use when" in skill.split("---", 2)[1]
     assert entry["version"] == "0.6.0"
+    assert entry["trustManifest"]["identity"] == "https://iparq.dev/"
+
+
+def test_catalog_site_has_agent_and_search_discovery_files() -> None:
+    homepage = (SITE_PATH / "index.html").read_text()
+    llms_txt = (SITE_PATH / "llms.txt").read_text()
+    agent_overview = (SITE_PATH / "index.md").read_text()
+    pricing = (SITE_PATH / "pricing.md").read_text()
+    robots = (SITE_PATH / "robots.txt").read_text()
+
+    assert '<script type="application/ld+json">' in homepage
+    assert 'rel="ai-catalog"' in homepage
+    assert "without uploading files" in homepage
+    assert "https://iparq.dev/docs/" in llms_txt
+    assert "uvx --refresh iparq inspect" in agent_overview
+    assert "free to install and use" in pricing
+    assert "Sitemap: https://iparq.dev/sitemap.xml" in robots
+
+
+def test_sitemap_uses_canonical_https_urls() -> None:
+    sitemap = ET.parse(SITE_PATH / "sitemap.xml")
+    namespace = {"sitemap": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    locations = [
+        element.text
+        for element in sitemap.findall("sitemap:url/sitemap:loc", namespace)
+    ]
+
+    assert "https://iparq.dev/" in locations
+    assert "https://iparq.dev/.well-known/ai-catalog.json" in locations
+    assert all(
+        location and location.startswith("https://iparq.dev/") for location in locations
+    )

--- a/tests/test_ai_catalog.py
+++ b/tests/test_ai_catalog.py
@@ -2,6 +2,7 @@ import json
 import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from urllib.parse import urlsplit
 
 
 REPOSITORY_ROOT = Path(__file__).parents[1]
@@ -68,6 +69,7 @@ def test_sitemap_uses_canonical_https_urls() -> None:
 
     assert "https://iparq.dev/" in locations
     assert "https://iparq.dev/.well-known/ai-catalog.json" in locations
-    assert all(
-        location and location.startswith("https://iparq.dev/") for location in locations
-    )
+    parsed_locations = [urlsplit(location) for location in locations if location]
+    assert len(parsed_locations) == len(locations)
+    assert all(location.scheme == "https" for location in parsed_locations)
+    assert all(location.hostname == "iparq.dev" for location in parsed_locations)


### PR DESCRIPTION
## What changed

- expand the static homepage with clear CLI, safety, and Agent Skill guidance
- publish `/docs/`, `/llms.txt`, `/index.md`, `/pricing.md`, and `/sitemap.xml`
- add Open Graph and `SoftwareApplication` JSON-LD metadata
- migrate the ARD resource identity to the domain-anchored `urn:air:iparq.dev:skill:parquet-inspector`
- point project metadata and documentation links at `iparq.dev`
- add focused catalog-site and sitemap tests

## Why

Ora validates the existing ARD catalog and PyPI CLI, but the site exposes too little human- and machine-readable context for cold-arrival agents. These changes improve discovery without turning the local, read-only CLI into a hosted API or MCP service.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/iparq --config-file=pyproject.toml`
- `uv run ty check`
- `uv run pytest -vv` (33 passed)
- wheel and sdist build plus `twine check`
- HTML5, JSON-LD, XML, and internal-link validation
- pinned ARD strict schema and semantic conformance (pass, zero warnings)
