### PR TITLE
Align catalog with iParq 0.7.0

### DIFF
--- a/.well-known/ai-catalog.json
+++ b/.well-known/ai-catalog.json
@@ -35,8 +35,8 @@
         "compare storage metadata across these Parquet files",
         "produce machine-readable metadata for this Parquet file"
       ],
-      "version": "0.6.0",
-      "updatedAt": "2026-07-22T00:00:00Z",
+      "version": "0.7.0",
+      "updatedAt": "2026-07-29T00:00:00Z",
       "metadata": {
         "package": "https://pypi.org/project/iparq/",
         "homepage": "https://iparq.dev/",

--- a/catalog-site/index.html
+++ b/catalog-site/index.html
@@ -23,7 +23,7 @@
         "applicationCategory": "DeveloperApplication",
         "applicationSubCategory": "Data engineering tool",
         "operatingSystem": "Linux, macOS, Windows",
-        "softwareVersion": "0.6.0",
+        "softwareVersion": "0.7.0",
         "programmingLanguage": "Python",
         "license": "https://opensource.org/license/mit",
         "downloadUrl": "https://pypi.org/project/iparq/",

--- a/tests/test_ai_catalog.py
+++ b/tests/test_ai_catalog.py
@@ -38,7 +38,7 @@ def test_cataloged_skill_exists_and_has_matching_identity() -> None:
     assert entry["type"] == 'text/markdown; profile="urn:air:agent-skills"'
     assert skill.startswith("---\nname: iparq-parquet-inspector\n")
     assert "Use when" in skill.split("---", 2)[1]
-    assert entry["version"] == "0.6.0"
+    assert entry["version"] == "0.7.0"
     assert entry["trustManifest"]["identity"] == "https://iparq.dev/"
 
 


### PR DESCRIPTION
## Summary

- align the public ARD catalog entry and site structured data with iParq 0.7.0
- advance the catalog update date to the release date
- update the catalog regression assertion

## Why

The live release read-back found that the package and GitHub release were correctly published as 0.7.0 while the separately deployed discovery catalog still advertised 0.6.0.

## Impact

Catalog-only metadata correction. The published PyPI artifacts and CLI behavior are unchanged.

## Validation

- catalog tests: 4 passed
- Ruff format and lint checks pass
- the Pages workflow will run the pinned ARD conformance validator before deployment
