### PR TITLE
Support Core Metadata 2.5 publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -130,7 +130,8 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        # v1.14.1, pinned to its peeled commit and matching GHCR image tag.
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247
+        # v1.14.2, pinned to its peeled commit and matching GHCR image tag.
+        # This release supports distributions using Core Metadata 2.5.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
         with:
           packages-dir: dist/


### PR DESCRIPTION
## Summary

Update `pypa/gh-action-pypi-publish` from v1.14.1 to the signed, peeled v1.14.2 commit so the trusted publisher can verify and upload distributions using Core Metadata 2.5.

## Root cause

The iParq 0.7.3 release build and tests succeeded, but publish run 31870032153 failed because the v1.14.1 action bundled Twine 6.1/Packaging 25 and rejected valid Metadata 2.5 before upload.

## Safety

- built-in metadata verification remains enabled
- trusted-publishing permissions and artifact flow are unchanged
- the signed v1.14.2 tag peels to the pinned SHA and bundles Twine 7.0.0/Packaging 26.2
- independent peer review completed with no remaining findings

## Validation

- `actionlint`
- signed tag and peeled commit verified via GitHub API
- local 0.7.3 build validated successfully with Twine 7.0.0